### PR TITLE
Fix Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,8 +44,8 @@ all: $(BINS) $(LIBS)
 
 install: $(all)
 	@echo "Installing..."
-	@install -D -t $(DESTDIR)$(BINDIR) $(BINS)
-	@install -D -t $(DESTDIR)$(LIBDIR) $(LIBS)
+	@install -D -t $(DESTDIR)$(BINDIR) $(BUILDDIR)/$(BINS)
+	@install -D -t $(DESTDIR)$(LIBDIR) $(BUILDDIR)/$(LIBS)
 	@install -D -t $(DESTDIR)$(DATADIR)/sys64/lock config.conf style.css
 
 clean:


### PR DESCRIPTION
Hi!
When I trying build a package with this tool, I'm get error:

```
Installing...
/bin/install: cannot stat 'syslock': No such file or directory
make: *** [Makefile:47: install] Error 1
```
After quick look I found the core of problem. The process of building is going in "build" directory, but install searching build artifacts in the root directory of project. So, i change paths in Makefile, and package was builded successfully!

Thank you for you work and good luck! :)